### PR TITLE
Add support on latest MySQL 8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,13 @@
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.29</version>
+        </dependency>
+
         <dependency>
             <groupId>com.github.hakan-krgn.hCore</groupId>
             <artifactId>hCore-bukkit</artifactId>

--- a/src/main/java/me/defender/cosmetics/database/mysql/MySQL.java
+++ b/src/main/java/me/defender/cosmetics/database/mysql/MySQL.java
@@ -34,6 +34,7 @@ public class MySQL {
             int port = plugin.getConfig().getInt("mysql.port", 3306);
 
             HikariConfig config = new HikariConfig();
+            config.setDriverClassName("com.mysql.cj.jdbc.Driver");
             config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database);
             config.setUsername(username);
             config.setPassword(password);


### PR DESCRIPTION
So i just do this because on Spigot 1.8.8 support older version of MySQL as MySQL 5 but mostly everyone just using MySQL 8 so it get error issue when using this, i add some code and Maven repo to support latest MySQL 8
Thanks!