### PR TITLE
[bug-fix] remove all entitys

### DIFF
--- a/cosmetic-api/src/main/java/xyz/iamthedefender/cosmetics/api/cosmetics/category/VictoryDance.java
+++ b/cosmetic-api/src/main/java/xyz/iamthedefender/cosmetics/api/cosmetics/category/VictoryDance.java
@@ -111,7 +111,18 @@ public abstract class VictoryDance extends Cosmetics {
         if (tasks.containsKey(winner)) tasks.get(winner).forEach(BukkitTask::cancel);
 
         if (entities.containsKey(winner)) {
-            entities.get(winner).forEach(Entity::remove);
+            entities.get(winner).forEach((e) -> {
+				var passengers = e.getPassengers();
+
+				if (passengers != null)
+					passengers.forEach(Entity::remove);
+
+				var vehicle = e.getVehicle();
+				if (vehicle != null)
+					vehicle.remove();
+
+				e.remove();
+			});
         }
     }
 


### PR DESCRIPTION
bug description: when some team win while using the victory dance "floating lantern" the riding armor stand are not removed
i am using 1.8.9 paper server