### PR TITLE
Fix /cosmetics main menu categories not opening

### DIFF
--- a/cosmetic-api/src/main/java/xyz/iamthedefender/cosmetics/api/cosmetics/CosmeticsType.java
+++ b/cosmetic-api/src/main/java/xyz/iamthedefender/cosmetics/api/cosmetics/CosmeticsType.java
@@ -43,13 +43,71 @@ public enum CosmeticsType {
         return configManager;
     }
 
+    /**
+     * Resolves a Main-Menu config key (e.g. {@code Victory-Dances}, {@code Bed-Destroys})
+     * or an enum/section name to a {@link CosmeticsType}.
+     * <p>
+     * Earlier versions only compared the raw key to {@link #name()}, so hyphenated
+     * Main-Menu entries never opened a category menu.
+     */
     public static CosmeticsType fromName(String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+
+        // Exact Main-Menu.yml keys used by openMenus(...)
+        switch (name) {
+            case "Sprays":
+                return Sprays;
+            case "Projectile-Trails":
+                return ProjectileTrails;
+            case "FinalKill-Effects":
+                return FinalKillEffects;
+            case "Kill-Messages":
+                return KillMessages;
+            case "Glyphs":
+                return Glyphs;
+            case "Bed-Destroys":
+                return BedBreakEffects;
+            case "WoodSkins":
+            case "Wood-Skins":
+                return WoodSkins;
+            case "Victory-Dances":
+                return VictoryDances;
+            case "Island-Toppers":
+            case "IslandToppers":
+                return IslandToppers;
+            case "ShopKeeperSkins":
+                return ShopKeeperSkins;
+            case "Death-Cries":
+                return DeathCries;
+            default:
+                break;
+        }
+
+        String compact = name.replace("-", "").replace("_", "");
+        String normalized = normalizeKey(name);
+
         for (CosmeticsType type : values()) {
-            if (type.name().replace("-", "").replace("_", "").equalsIgnoreCase(name)) {
+            if (type.name().equalsIgnoreCase(name) || type.name().equalsIgnoreCase(compact)) {
+                return type;
+            }
+            if (normalizeKey(type.name()).equals(normalized)
+                    || normalizeKey(type.sectionKey).equals(normalized)
+                    || normalizeKey(type.formatedName).equals(normalized)) {
                 return type;
             }
         }
         return null;
+    }
+
+    private static String normalizeKey(String s) {
+        String out = s.toLowerCase().replaceAll("[^a-z0-9]", "");
+        // Bed-Destroys -> beddestroy, death-cry -> deathcry (singularize trailing s only)
+        if (out.endsWith("s") && out.length() > 1) {
+            out = out.substring(0, out.length() - 1);
+        }
+        return out;
     }
 
 }

--- a/cosmetic-plugin/src/main/java/xyz/iamthedefender/cosmetics/category/deathcries/DeathCrySBW.java
+++ b/cosmetic-plugin/src/main/java/xyz/iamthedefender/cosmetics/category/deathcries/DeathCrySBW.java
@@ -37,10 +37,11 @@ public class DeathCrySBW implements Listener {
                 } catch (NoSuchElementException exception){
                     exception.printStackTrace();
                     Bukkit.getLogger().severe(deathCry.getIdentifier() + "Death cry has invalid sound!");
-                }finally {
+                } finally {
                     try {
-                        event.setPlaySound(false);
-                    }catch (Throwable throwable) {
+                        // Reflective call — method exists only on ScreamingBedWars 0.2.41+
+                        event.getClass().getMethod("setPlaySound", boolean.class).invoke(event, false);
+                    } catch (Throwable throwable) {
                         CosmeticsPlugin.getInstance().getLogger().severe("Failed to disable default sounds from ScreamingBedWars, please make sure you are using ScreamingBedWars 0.2.41-SNAPSHOT or higher!");
                     }
                 }

--- a/cosmetic-plugin/src/main/java/xyz/iamthedefender/cosmetics/menu/CategoryMenu.java
+++ b/cosmetic-plugin/src/main/java/xyz/iamthedefender/cosmetics/menu/CategoryMenu.java
@@ -48,17 +48,24 @@ public class CategoryMenu extends ChestSystemGui {
         this.config = type.getConfig();
         this.cosmeticsType = type;
         this.title = title;
+        List<Integer> defaultSlots = Arrays.asList(10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 24, 25, 28, 29, 30, 31, 32, 33, 34);
         String list = config.getString("slots");
-        list = list.replace("[", "").replace("]", "");
         List<Integer> integerList = new ArrayList<>();
-        for (String s : list.split("\\s*,\\s*")) {
-            integerList.add(Integer.parseInt(s));
+        if (list != null && !list.isEmpty()) {
+            list = list.replace("[", "").replace("]", "");
+            for (String s : list.split("\\s*,\\s*")) {
+                if (s.isEmpty()) {
+                    continue;
+                }
+                try {
+                    integerList.add(Integer.parseInt(s.trim()));
+                } catch (NumberFormatException ignored) {
+                    // skip invalid slot entries
+                }
+            }
         }
-        slots = integerList;
-        if (slots.isEmpty()){
-            slots = Arrays.asList(10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34);
-        }
-       this.page = page;
+        slots = integerList.isEmpty() ? defaultSlots : integerList;
+        this.page = page;
     }
 
     public CategoryMenu(CosmeticsType type, String title) {

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Fix `CosmeticsType.fromName` so hyphenated Main-Menu.yml keys (`Victory-Dances`, `Projectile-Trails`, `Bed-Destroys`, etc.) correctly open category menus
- Harden `CategoryMenu` slots parsing when `slots` is missing/invalid
- Use reflection for ScreamingBedWars `setPlaySound` so the plugin builds against older API jars
- Bump Lombok for Java 21 builds

## Test plan
- [ ] Open `/cosmetics` and click every category (Victory Dances, Projectile Trails, Final Kill Effects, Kill Messages, Bed Destroys, Death Cries, and the ones that already worked)
- [ ] Confirm each opens its category GUI instead of doing nothing
- [ ] Confirm Back/Balance still behave as before

Made with [Cursor](https://cursor.com)